### PR TITLE
Fix copy to clipboard bug

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -31,7 +31,7 @@ function formatEmailList() {
 }
 
 var mostRecentSpanElement;
-function copyToClipboard(spanElement, copyText, isPermalink) {
+function copyToClipboard(spanElement, copyText) {
 	if (mostRecentSpanElement) {
 		mostRecentSpanElement.innerHTML = "🔗";
 	}
@@ -40,8 +40,7 @@ function copyToClipboard(spanElement, copyText, isPermalink) {
 	mostRecentSpanElement = spanElement;
 
 	const element = document.createElement('textarea');
-	let copyValue = copyText;
-	if (isPermalink) copyValue = 'https://defund12.org'.concat(copyText)
+	let copyValue = 'https://defund12.org'.concat(copyText)
 	element.value = copyValue;
 	document.body.appendChild(element);
 	element.select();


### PR DESCRIPTION
I found that `isPermaLink` was undefined and the only things being copied to the clipboard were `/la` or `/ny`.

This PR lets the entire URL be copied to the clipboard.