### PR TITLE
Fix typo in recipient email address (Austin)

### DIFF
--- a/_emails/austin.md
+++ b/_emails/austin.md
@@ -11,7 +11,7 @@ recipients:
 - Delia.Garza@austintexas.gov
 - Sabino.Renteria@austintexas.gov
 - Greg.Casar@austintexas.gov
-- Ann.Kitchen@austinteas.gov
+- Ann.Kitchen@austintexas.gov
 - jimmy.flannigan@austintexas.gov
 - Leslie.Pool@austintexas.gov
 - Paige.Ellis@austintexas.gov


### PR DESCRIPTION
The email address for Austin council member Ann Kitchen has a typo in it