### PR TITLE
Add Bobby Henon's phila.gov email

### DIFF
--- a/_emails/philadelphia.md
+++ b/_emails/philadelphia.md
@@ -21,6 +21,7 @@ recipients:
 - Curtis.Jones.Jr@phila.gov
 - Samantha.Williams@Phila.gov
 - bobby@bobbyhenon.com
+- Bobby.Henon@Phila.gov
 - Lauren.Atwell@phila.gov
 - Katherine.Gilmore.Richardson@phila.gov
 - Shawn.Baldwin@Phila.gov


### PR DESCRIPTION
bobbyhenon.com is suspended, and I doubt he's still receiving emails there.